### PR TITLE
Fix dependency issue and interactive crash

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 */__pycache__/*
 .venv/*
+.vscode/*

--- a/lib/interactive.py
+++ b/lib/interactive.py
@@ -162,7 +162,7 @@ class InteractiveShell(cmd.Cmd):
             obj_name = "Media"
         elif obj_type == WPApi.NAMESPACE:
             display_func = InfoDisplayer.display_namespaces
-            export_func = Exporter.export_media
+            export_func = Exporter.export_namespaces
             additional_info = {}
             obj_name = "Namespaces" if plural else "Namespace"
 

--- a/lib/requestsession.py
+++ b/lib/requestsession.py
@@ -104,12 +104,15 @@ class RequestSession:
         Helper class to regroup requests and handle exceptions at the same
         location
         """
+        headers = {
+            'User-Agent': 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/113.0.0.0 Safari/537.36'
+        }
         response = None
         try:
             if method == "post":
-                response = self.s.post(url, data)
+                response = self.s.post(url, data, headers=headers)
             else:
-                response = self.s.get(url)
+                response = self.s.get(url, headers=headers)
         except requests.ConnectionError as e:
             if "Errno -5" in str(e) or "Errno -2" in str(e)\
               or "Errno -3" in str(e):

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ certifi==2020.4.5.1
 chardet==3.0.4
 idna==2.9
 requests==2.23.0
-urllib3==1.26.5
+urllib3==1.25.9


### PR DESCRIPTION
* Downgrade urllib to 1.25.9, pip complains it can't resolve dependencies on 1.26.5

```
ERROR: Cannot install requests==2.23.0 and urllib3==1.26.5 because these package versions have conflicting dependencies.

The conflict is caused by:
    The user requested urllib3==1.26.5
    requests 2.23.0 depends on urllib3!=1.25.0, !=1.25.1, <1.26 and >=1.21.1
```

* Fix interactive export to call placeholder `export_namespaces` function instead of `export_media` as this causes a crash